### PR TITLE
Implement ExitIdle on the balancer

### DIFF
--- a/balancer.go
+++ b/balancer.go
@@ -383,6 +383,12 @@ func (b *ringBalancer) Close() {
 	// No internal state to clean up and no need to call RemoveSubConn.
 }
 
+func (b *ringBalancer) ExitIdle() {
+	// No-op as we already reconnect SubConns on demand when they report
+	// connectivity.Idle in UpdateSubConnState. This is here to satisfy
+	// the balancer.Balancer interface >v1.74.0
+}
+
 type picker struct {
 	hashring *hashring.Ring
 	spread   uint8


### PR DESCRIPTION


<!--
If your PR is not ready to be reviewed or merged, please submit it as a "draft".
-->

## Description

<!--
Why do we need this PR? Any implementation details worth mentioning here?
-->

go-grpc@1.74.0 introduced a breaking change to the balancer.Balancer interface by introducing a new method. To still satisfy that interface we need to implement ExitIdle. It's been an optional part of the balancer, as a seperate interface, for quite a while. And since it's not implementing ExitIdle already, I assume it's safe to do a no-op.

## Testing

<!--
How did you test this and how can reviewers test this?
-->

No new behavior is added. I guess it could be better verified that it complies with the interface by upgrading to go-grpc >1.74.0. 

## References

<!--
GitHub Issue, Discord or Slack threads, etc.
-->
#1 
https://github.com/grpc/grpc-go/issues/8345